### PR TITLE
Add description for CFrame rotational data

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -271,7 +271,7 @@ After | "F" | 0×83 | 0×0701 | 0×76c309 | 0×000b | 0×7b | 0×02 | 0×01c5b60
 
 #### General Case
 
-In the general case, CFrames have some arbitrary rotation that is not clean multiples of 90 degrees. This means that the rotation will not or cannot be enumerated, and therefore must be sent entirely. We do not understand the rotation format, but it is 6 bytes long, so forgive the elusive formatting we use. If you would like to help us figure out the rotation format, you may download the packet viewer, run the tests you need to, and make a pull request improving [Squash's documentation](https://github.com/Data-Oriented-House/Squash)!
+In the general case, CFrames have some arbitrary rotation that is not clean multiples of 90 degrees. This means that the rotation will not or cannot be enumerated, and therefore must be sent entirely. CFrames use 6 bytes to represent their rotation with 3 float16s. Since CFrames utilize quaternions which have four rotational components, the last component is calculated on the other side; this can be confirmed because the rotation quaternions are normalized, meaning they have three degrees of freedom instead of four. Due to this, the fourth rotational component can instead be derived from the other three.
 
 | Type 0×1b (byte) | X (4 bytes) | Y (4 bytes) | Z (4 bytes) | Id 0×00 (byte) | Rotation (6 bytes) |
 |-|-|-|-|-|-|


### PR DESCRIPTION
CFrames' rotational components are normalized when sent through remotes, as confirmed by sending a sample CFrame through a remote like so:
```lua
-- server
RemoteEvent:FireAllClients(CFrame.fromMatrix(Vector3.zero, Vector3.new(2, 0, 0), Vector3.new(0, 3, 0)))

-- client
RemoteEvent.OnClientEvent:Connect(function(cf)
        -- false, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1 (same as OriginalCF:Orthonormalize())
	print(CFrame.fromMatrix(Vector3.zero, Vector3.new(2, 0, 0), Vector3.new(0, 3, 0)) == cf, cf)
end)
```
Since CFrames are orthnormalized, there end up only being three degrees of freedom instead of four; which means the fourth quaternion can be calculated through `w = sqrt(1 - x^2 - y^2 - z^2)`.

This information was mainly based off of http://physicsforgames.blogspot.com/2010/03/quaternion-tricks.html, and is highly likely to be the implementation Roblox uses thanks to confirming the cframes' enforced orthogonality when passed through remotes.