### PR TITLE
Add literals 

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -868,7 +868,7 @@ local function map<K, V>(keySerDes: SerDes<K>, valueSerDes: SerDes<V>): SerDes<{
 end
 Squash.map = map
 
-local function literal(...:any): SerDes<any>
+local function literal(...: any): SerDes<any>
 	local literals = { ... }
 	local lookup = {}
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -868,12 +868,12 @@ local function map<K, V>(keySerDes: SerDes<K>, valueSerDes: SerDes<V>): SerDes<{
 end
 Squash.map = map
 
-local function literal<T>(literals: {T}): SerDes<T>
+local function literal(literals: { any }): SerDes<any>
 	local literalsSet = {}
 	local reverseLiteralsSet = {}
 
 	local count = 0
-	for _, literal in literals :: any do
+	for _, literal in literals do
 		if literalsSet[literal] then
 			continue
 		end

--- a/src/init.luau
+++ b/src/init.luau
@@ -868,6 +868,38 @@ local function map<K, V>(keySerDes: SerDes<K>, valueSerDes: SerDes<V>): SerDes<{
 end
 Squash.map = map
 
+local function literal<T>(literals: T & {}): SerDes<T>
+	local literalsSet = {}
+	local reverseLiteralsSet = {}
+
+	local count = 0
+	for _, literal in literals :: any do
+		if literalsSet[literal] then
+			continue
+		end
+
+		literalsSet[literal] = count
+		reverseLiteralsSet[count] = literal
+
+		count += 1
+	end
+
+	-- It is unrealistic for more than 2^16 literals to be used.
+	local push: (cursor: Cursor, literal: number) -> () = if count < 256 then pushu1 else pushu2
+	local pop: (cursor: Cursor) -> number = if count < 256 then popu1 else popu2
+
+	return {
+		ser = function(cursor, literal)
+			push(cursor, literalsSet[literal])
+		end,
+
+		des = function(cursor)
+			return reverseLiteralsSet[pop(cursor)]
+		end,
+	}
+end
+Squash.literal = literal
+
 local function tableserdes(schema: { [string]: SerDes<any> }): SerDes<any>
 	local typemap = {}
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -868,7 +868,7 @@ local function map<K, V>(keySerDes: SerDes<K>, valueSerDes: SerDes<V>): SerDes<{
 end
 Squash.map = map
 
-local function literal<T>(literals: T & {}): SerDes<T>
+local function literal<T>(literals: {T}): SerDes<T>
 	local literalsSet = {}
 	local reverseLiteralsSet = {}
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -868,33 +868,21 @@ local function map<K, V>(keySerDes: SerDes<K>, valueSerDes: SerDes<V>): SerDes<{
 end
 Squash.map = map
 
-local function literal(literals: { any }): SerDes<any>
-	local literalsSet = {}
-	local reverseLiteralsSet = {}
+local function literal(...:any): SerDes<any>
+	local literals = { ... }
+	local lookup = {}
 
-	local count = 0
-	for _, literal in literals do
-		if literalsSet[literal] then
-			continue
-		end
-
-		literalsSet[literal] = count
-		reverseLiteralsSet[count] = literal
-
-		count += 1
+	for i, literal in literals do
+		lookup[literal] = i
 	end
-
-	-- It is unrealistic for more than 2^16 literals to be used.
-	local push: (cursor: Cursor, literal: number) -> () = if count < 256 then pushu1 else pushu2
-	local pop: (cursor: Cursor) -> number = if count < 256 then popu1 else popu2
 
 	return {
 		ser = function(cursor, literal)
-			push(cursor, literalsSet[literal])
+			pushu1(cursor, lookup[literal])
 		end,
 
 		des = function(cursor)
-			return reverseLiteralsSet[pop(cursor)]
+			return literals[popu1(cursor)]
 		end,
 	}
 end

--- a/src/moonwave.luau
+++ b/src/moonwave.luau
@@ -199,7 +199,7 @@
 
 --- @function literal
 --- @within Squash
---- @param literals { any }
+--- @param literals ... any
 --- @return SerDes<any>
 
 -- --- @class table

--- a/src/moonwave.luau
+++ b/src/moonwave.luau
@@ -195,6 +195,13 @@
 --- @param valueSerDes SerDes<V>
 --- @return SerDes<{[K]: V}>
 
+-- --- @class literal
+
+--- @function literal
+--- @within Squash
+--- @param literals {T}
+--- @return SerDes<T>
+
 -- --- @class table
 
 --[=[

--- a/src/moonwave.luau
+++ b/src/moonwave.luau
@@ -199,8 +199,8 @@
 
 --- @function literal
 --- @within Squash
---- @param literals {T}
---- @return SerDes<T>
+--- @param literals { any }
+--- @return SerDes<any>
 
 -- --- @class table
 

--- a/tests/UnitTests.server.luau
+++ b/tests/UnitTests.server.luau
@@ -701,6 +701,19 @@ print(playerserdes.des(cursor))
 --     ["position"] = 287.385498, -13486.2998
 --  }
 
+--* Literals
+
+local literal = Squash.literal({"a", "b", "c", "d", "e"})
+
+local cursor = Squash.cursor()
+literal.ser(cursor, "d")
+Squash.print(cursor)
+-- Pos: 1 / 8
+-- Buf: { 3 0 0 0 0 0 0 0 }
+--          ^
+print(literal.des(cursor))
+-- "d"
+
 --* Tuples
 
 local S = Squash

--- a/tests/UnitTests.server.luau
+++ b/tests/UnitTests.server.luau
@@ -703,7 +703,7 @@ print(playerserdes.des(cursor))
 
 --* Literals
 
-local literal = Squash.literal({"a", "b", "c", "d", "e"})
+local literal = Squash.literal("a", "b", "c", "d", "e")
 
 local cursor = Squash.cursor()
 literal.ser(cursor, "d")


### PR DESCRIPTION
My motivation for this is to be able to replicate string literals like map and character names. I was originally going to call it `stringLiteral`, however I realized this can be used for almost any values. So a more generic name of `literal` was used.
```lua
local literal = Squash.literal( "dog", "cat", "mouse" )

local cursor = Squash.cursor()
literal.ser(cursor, "cat")

print(literal.des(cursor)) -- "cat"
```

### notes
- I felt it was unrealistic to use more than 2^16 literals, so it only uses u1 and u2 depending on the amount of literals.
- None of the other methods have much error checking, so I also left that out (assuming for performance).
- I tried to follow how map and records "tests" are written.