### PR TITLE
cframe serialize optimiation for special cases

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -1062,15 +1062,8 @@ function Squash.CatalogueSearchParams(): SerDes<CatalogSearchParams>
 	return catalogueSearchParamsCache
 end
 
-local idToCFrame
-local cframeCache = {}
-local function cframe(positionSerDes: SerDes<number>): SerDes<CFrame>
-	if cframeCache[positionSerDes] then
-		return cframeCache[positionSerDes]
-	end
-
-	--? Not defined outside so pure Luau users don't suffer errors
-	idToCFrame = idToCFrame or {
+local function cframeLookupEntries()
+	return {
 		CFrame.Angles(0, 0, 0),
 		CFrame.Angles(math.rad(90), 0, 0),
 		CFrame.Angles(0, math.rad(180), math.rad(180)),
@@ -1096,12 +1089,37 @@ local function cframe(positionSerDes: SerDes<number>): SerDes<CFrame>
 		CFrame.Angles(0, math.rad(90), 0),
 		CFrame.Angles(math.rad(-90), math.rad(90), 0),
 	}
+end
+
+local function cframeSpecialCaseLookup()
+	local lookup = {}
+
+	local entries = cframeLookupEntries()
+
+	for i,v in pairs(entries) do
+		lookup[Vector3.new(v:ToOrientation())] = i
+	end
+
+	return lookup
+end
+
+local idToCFrame
+local cframeToId
+local cframeCache = {}
+local function cframe(positionSerDes: SerDes<number>): SerDes<CFrame>
+	if cframeCache[positionSerDes] then
+		return cframeCache[positionSerDes]
+	end
+
+	--? Not defined outside so pure Luau users don't suffer errors
+	cframeToId = cframeToId or cframeSpecialCaseLookup()
+	idToCFrame = idToCFrame or cframeLookupEntries()
 
 	local push, pop = positionSerDes.ser, positionSerDes.des
 
 	local cframeserdes: SerDes<CFrame> = {
 		ser = function(cursor, cframe)
-			local specialId = table.find(idToCFrame, cframe.Rotation)
+			local specialId = cframeToId[Vector3.new(cframe:ToOrientation())]
 			if specialId then
 				pushu1(cursor, specialId)
 			else


### PR DESCRIPTION
There was some performance overhead with the table.find() lookup for special cases in cframes, I've switched it to a table lookup to save on performance.

Here's the original version's benchmark, note the somewhat noisy taper
![image](https://github.com/user-attachments/assets/2191484e-3268-4291-acd1-acfe82f4c9aa)

Here's the optimized version
![image](https://github.com/user-attachments/assets/6edff6bf-1224-48e5-b119-de72324eafc1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized the handling of rotation data by streamlining its conversion and serialization process for improved efficiency and clarity. These internal enhancements ensure a smoother and more reliable management of transformation states across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->