### PR TITLE
Encode CFrame rotation as a Quaternion for better accuracy

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -1100,36 +1100,40 @@ local function cframe(positionSerDes: SerDes<number>): SerDes<CFrame>
 	local push, pop = positionSerDes.ser, positionSerDes.des
 
 	local cframeserdes: SerDes<CFrame> = {
-		ser = function(cursor, cframe)
-			local specialId = table.find(idToCFrame, cframe.Rotation)
-			if specialId then
-				pushu1(cursor, specialId)
-			else
-				local axis, theta = cframe:ToAxisAngle()
-				local rotaxis = axis * theta * 256
-				pushi2(cursor, rotaxis.Z)
-				pushi2(cursor, rotaxis.Y)
-				pushi2(cursor, rotaxis.X)
-				pushu1(cursor, 0)
-			end
-			local pos = cframe.Position
-			push(cursor, pos.Z)
-			push(cursor, pos.Y)
-			push(cursor, pos.X)
-		end,
+        ser = function(cursor, cframe)
+            local specialId = table.find(idToCFrame, cframe.Rotation)
+            if specialId then
+                pushu1(cursor, specialId)
+            else
+                local axis, theta = cframe:ToAxisAngle()
+                axis*=math.sin(theta/2)
+                pushu2(cursor, (axis.Z + 1) * (65535/2))
+                pushu2(cursor, (axis.Y + 1) * (65535/2))
+                pushu2(cursor, (axis.X + 1) * (65535/2))
+                pushu1(cursor, 0)
+            end
+            local pos = cframe.Position
+            push(cursor, pos.Z)
+            push(cursor, pos.Y)
+            push(cursor, pos.X)
+        end,
 
-		des = function(cursor)
-			local pos = Vector3.new(pop(cursor), pop(cursor), pop(cursor))
+        des = function(cursor)
+            local x,y,z = pop(cursor), pop(cursor), pop(cursor)
 
-			local specialId = popu1(cursor)
-			if specialId ~= 0 then
-				return idToCFrame[specialId] + pos
-			end
+            local specialId = popu1(cursor)
+            if specialId ~= 0 then
+                return idToCFrame[specialId] + Vector3.new(x,y,z)
+            end
 
-			local rotaxis = Vector3.new(popi2(cursor), popi2(cursor), popi2(cursor)) / 256
-			return CFrame.fromAxisAngle(rotaxis.Unit, rotaxis.Magnitude) + pos
-		end,
-	}
+            local qx = popu2(cursor) * (2 / 65535) - 1 
+            local qy = popu2(cursor) * (2 / 65535) - 1 
+            local qz = popu2(cursor) * (2 / 65535) - 1 
+            local qw = math.sqrt(1- qx*qx - qy*qy - qz*qz)
+            
+            return CFrame.new(x,y,z,qx,qy,qz,qw)
+        end,
+    }
 	cframeCache[positionSerDes] = cframeserdes
 	return cframeserdes
 end

--- a/src/init.luau
+++ b/src/init.luau
@@ -845,8 +845,8 @@ local function map<K, V>(keySerDes: SerDes<K>, valueSerDes: SerDes<V>): SerDes<{
 		ser = function(cursor, map)
 			local size = 0
 			for k, v in map :: any do
-				(valueSerDes :: any).ser(cursor, v)
-				;(keySerDes :: any).ser(cursor, k)
+				(valueSerDes :: any).ser(cursor, v);
+(keySerDes :: any).ser(cursor, k)
 				size += 1
 			end
 			pushvlq(cursor, size)
@@ -1100,40 +1100,40 @@ local function cframe(positionSerDes: SerDes<number>): SerDes<CFrame>
 	local push, pop = positionSerDes.ser, positionSerDes.des
 
 	local cframeserdes: SerDes<CFrame> = {
-        ser = function(cursor, cframe)
-            local specialId = table.find(idToCFrame, cframe.Rotation)
-            if specialId then
-                pushu1(cursor, specialId)
-            else
-                local axis, theta = cframe:ToAxisAngle()
-                axis*=math.sin(theta/2)
-                pushu2(cursor, (axis.Z + 1) * (65535/2))
-                pushu2(cursor, (axis.Y + 1) * (65535/2))
-                pushu2(cursor, (axis.X + 1) * (65535/2))
-                pushu1(cursor, 0)
-            end
-            local pos = cframe.Position
-            push(cursor, pos.Z)
-            push(cursor, pos.Y)
-            push(cursor, pos.X)
-        end,
+		ser = function(cursor, cframe)
+			local specialId = table.find(idToCFrame, cframe.Rotation)
+			if specialId then
+				pushu1(cursor, specialId)
+			else
+				local axis, theta = cframe:ToAxisAngle()
+				axis *= math.sin(theta / 2)
+				pushu2(cursor, (axis.Z + 1) * (65535 / 2))
+				pushu2(cursor, (axis.Y + 1) * (65535 / 2))
+				pushu2(cursor, (axis.X + 1) * (65535 / 2))
+				pushu1(cursor, 0)
+			end
+			local pos = cframe.Position
+			push(cursor, pos.Z)
+			push(cursor, pos.Y)
+			push(cursor, pos.X)
+		end,
 
-        des = function(cursor)
-            local x,y,z = pop(cursor), pop(cursor), pop(cursor)
+		des = function(cursor)
+			local x, y, z = pop(cursor), pop(cursor), pop(cursor)
 
-            local specialId = popu1(cursor)
-            if specialId ~= 0 then
-                return idToCFrame[specialId] + Vector3.new(x,y,z)
-            end
+			local specialId = popu1(cursor)
+			if specialId ~= 0 then
+				return idToCFrame[specialId] + Vector3.new(x, y, z)
+			end
 
-            local qx = popu2(cursor) * (2 / 65535) - 1 
-            local qy = popu2(cursor) * (2 / 65535) - 1 
-            local qz = popu2(cursor) * (2 / 65535) - 1 
-            local qw = math.sqrt(1- qx*qx - qy*qy - qz*qz)
-            
-            return CFrame.new(x,y,z,qx,qy,qz,qw)
-        end,
-    }
+			local qx = popu2(cursor) * (2 / 65535) - 1
+			local qy = popu2(cursor) * (2 / 65535) - 1
+			local qz = popu2(cursor) * (2 / 65535) - 1
+			local qw = math.sqrt(1 - qx * qx - qy * qy - qz * qz)
+
+			return CFrame.new(x, y, z, qx, qy, qz, qw)
+		end,
+	}
 	cframeCache[positionSerDes] = cframeserdes
 	return cframeserdes
 end

--- a/src/init.luau
+++ b/src/init.luau
@@ -845,8 +845,8 @@ local function map<K, V>(keySerDes: SerDes<K>, valueSerDes: SerDes<V>): SerDes<{
 		ser = function(cursor, map)
 			local size = 0
 			for k, v in map :: any do
-				(valueSerDes :: any).ser(cursor, v);
-(keySerDes :: any).ser(cursor, k)
+				(valueSerDes :: any).ser(cursor, v)
+				;(keySerDes :: any).ser(cursor, k)
 				size += 1
 			end
 			pushvlq(cursor, size)


### PR DESCRIPTION
This method still uses 6 bytes for the non-special case rotations while ensuring a higher precision.

![image](https://github.com/user-attachments/assets/33ae1f2b-eb54-4780-91fa-1911cd440873)
Code used for testing
```lua
local SquashModified = require(script.Parent.SquashModified)
local Squash = require(script.Parent.Squash)

local int = Squash.int(1)
local function serAngles(x,y,z)
    local cf = CFrame.Angles(math.rad(x),math.rad(y),math.rad(z))
    print('------------------------------------')
    do
        local rx,ry,rz = cf:ToEulerAnglesXYZ()
        print('Expected: ',math.deg(rx),math.deg(ry),math.deg(rz))
    end
    do
        local cursor = Squash.cursor()
        Squash.CFrame(int).ser(cursor,cf)
        local buf = Squash.tobuffer(cursor)
        local cursor = Squash.frombuffer(buf)
        local new = Squash.CFrame(int).des(cursor)
        local rx,ry,rz = new:ToEulerAnglesXYZ()
        print('Original: ',math.deg(rx),math.deg(ry),math.deg(rz))
    end
    do
        local cursor = SquashModified.cursor()
        SquashModified.CFrame(int).ser(cursor,cf)
        local buf = SquashModified.tobuffer(cursor)
        local cursor = SquashModified.frombuffer(buf)
        local new = SquashModified.CFrame(int).des(cursor)
        local rx,ry,rz = new:ToEulerAnglesXYZ()
        print('Modified: ',math.deg(rx),math.deg(ry),math.deg(rz))
    end
end

local r = Random.new(671)
serAngles(321.13121,451,63)
local iters = 12
for i = 1, iters do
    serAngles(r:NextInteger(-1000,1000),r:NextInteger(-1000,1000),r:NextInteger(-1000,1000))
end
```