### PR TITLE
Fix issues with CatalogSearchParams SerDes

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -1175,7 +1175,7 @@ local catalogueSearchParamsCache: SerDes<CatalogSearchParams> = {
 		end
 		params.AssetTypes = assetTypes
 
-		params.SalesTypesFilter = enumitem(Enum.SalesTypeFilter).des(cursor)
+		params.SalesTypeFilter = enumitem(Enum.SalesTypeFilter).des(cursor)
 		params.CategoryFilter = enumitem(Enum.CatalogCategoryFilter).des(cursor) :: Enum.CatalogCategoryFilter
 		params.SortAggregation = enumitem(Enum.CatalogSortAggregation).des(cursor)
 		params.SortType = enumitem(Enum.CatalogSortType).des(cursor) :: Enum.CatalogSortType
@@ -1185,6 +1185,7 @@ local catalogueSearchParamsCache: SerDes<CatalogSearchParams> = {
 		params.MinPrice = popu4(cursor)
 		params.Limit = popu1(cursor)
 		params.IncludeOffSale = popbool(cursor)
+		return params
 	end,
 }
 function Squash.CatalogueSearchParams(): SerDes<CatalogSearchParams>


### PR DESCRIPTION
Fixes 2 issues with the CatalogSearchParams SerDes object, both in the `des` function:
1. `params.SalesTypesFilter` is not a valid field and will always throw an error. Changed to `SalesTypeFilter`.
2. Even if the above issue didn't exist, the `return params` statement is missing. Added that.

Might I also recommend changing the name of the constructor in the API to `CatalogSearchParams` to maintain parity with the ROBLOX API?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the mapping of search parameters to ensure proper configuration.
  - Ensured complete and accurate processing of search parameters during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->